### PR TITLE
Repo hygiene: add LICENSE, CONTRIBUTING, ROADMAP + Security lesson outline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ more complete are very welcome.
 Most of the course needs **no GPU**:
 
 ```bash
-make check          # verify docker, kind, kubectl, helm, jq
+make check          # verify docker, kind, kubectl, helm, kwok, jq
 make phase1-up      # a fake GPU fleet on kind + KWOK
 make phase1-demo    # schedulable + intentionally-Pending GPU workloads
 make phase1-down    # tear it down

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing
+
+Thanks for your interest in improving **AI Factory Operations Lab**. This is a
+learn-by-doing course, and contributions that make the labs clearer, more correct, or
+more complete are very welcome.
+
+## Ways to help
+
+- **Try a lab and report friction.** If a step is unclear or an expected output is wrong,
+  open an issue. That feedback is gold.
+- **Pick up a roadmap item.** See the [roadmap board](https://github.com/users/ld-singh/projects/1)
+  and the [issues](https://github.com/ld-singh/ai-factory-ops-lab/issues), especially those
+  tagged `good first issue` and `help wanted`.
+- **Add or extend a lesson.** Lessons tagged `lesson` on the roadmap are open for authoring.
+
+## Running the labs locally
+
+Most of the course needs **no GPU**:
+
+```bash
+make check          # verify docker, kind, kubectl, helm, jq
+make phase1-up      # a fake GPU fleet on kind + KWOK
+make phase1-demo    # schedulable + intentionally-Pending GPU workloads
+make phase1-down    # tear it down
+```
+
+Serve the docs site while editing:
+
+```bash
+pip install -r requirements-docs.txt
+make docs-serve     # http://localhost:8001
+```
+
+## House rules (what keeps this course trustworthy)
+
+These are the principles the whole project is built on. Please keep to them:
+
+1. **Simulation vs real GPU is always explicit.** Never let a README or report imply that a
+   fake-GPU simulation proves real hardware behaviour (CUDA, NCCL, NVLink, MIG, GPUDirect
+   RDMA, or real GPU memory). Each lesson states its **mode** and what it does and does not
+   prove. See [`fake-vs-real-limitations.md`](./portfolio-lab/06-validation-reports/fake-vs-real-limitations.md).
+2. **A module is only "Complete" when its validation report holds real captured output.**
+   Claims are backed by evidence, not prose.
+3. **No invented commands or flags.** For NVIDIA / KAI / BCM / Slurm specifics, defer to the
+   official docs and link them.
+4. **Teach the concept, keep it readable.** Every command pairs with the *why*, and steps
+   have an expected output and a checkpoint.
+
+## Pull request flow
+
+1. Fork and branch (`feat/...`, `docs/...`, or `lesson/...`).
+2. Make your change. If you touched docs, confirm the site builds:
+   ```bash
+   ./scripts/sync-docs.sh && mkdocs build
+   ```
+3. Keep the existing style: short paragraphs, expected outputs, and the per-lesson rhythm.
+4. Open the PR with a clear description of what it changes and why.
+
+## Reporting issues
+
+Use the [issue tracker](https://github.com/ld-singh/ai-factory-ops-lab/issues). For a lab
+problem, include the lesson, the command you ran, and the output you got versus what you
+expected.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Lovedeep Singh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,33 @@
+# Roadmap
+
+The live, tracked roadmap is the GitHub project board:
+**[AI Factory Ops Lab - Roadmap](https://github.com/users/ld-singh/projects/1)**.
+This file is the human-readable overview; the board is where work is tracked.
+
+## Where the course stands
+
+**Shipped and validated:**
+
+- Lessons 1-5 (simulation): Kubernetes GPU scheduling, KAI queueing, HAMi fractional
+  scheduling, Slurm (fake GRES), observability, inference harness, BCM-style lifecycle.
+- Lesson 6 real-GPU capstone, Parts A, B and C validated on real hardware (runtime path +
+  DCGM, HAMi sharing, inference benchmark).
+
+## Planned
+
+Tracked as issues on the board. Themes:
+
+| Theme | Item | Issue |
+|---|---|---|
+| Security | Lesson 7: Security for GPU/AI infrastructure | [#10](https://github.com/ld-singh/ai-factory-ops-lab/issues/10) |
+| Cost | Lesson 8: Cost & autoscaling for GPU platforms | [#11](https://github.com/ld-singh/ai-factory-ops-lab/issues/11) |
+| Scale | Concepts: the multi-node boundary (NCCL, NVLink, GPUDirect RDMA, InfiniBand) | [#12](https://github.com/ld-singh/ai-factory-ops-lab/issues/12) |
+| Real GPU | Lesson 6 Part D: Slurm real GRES enforcement on hardware | [#13](https://github.com/ld-singh/ai-factory-ops-lab/issues/13) |
+| Concepts | MIG (hardware partitioning) vs HAMi (software sharing) | [#14](https://github.com/ld-singh/ai-factory-ops-lab/issues/14) |
+| Project | CI: mkdocs build + markdown lint on PRs | [#15](https://github.com/ld-singh/ai-factory-ops-lab/issues/15) |
+| Docs | asciinema / GIF of a lab running in the README | [#16](https://github.com/ld-singh/ai-factory-ops-lab/issues/16) |
+
+## Contributing
+
+Items tagged `help wanted` and `good first issue` are the best places to start. See
+[CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
           - "Part B - HAMi isolation (real GPU)": portfolio-lab/01-k8s-gpu-platform/hami/hami-isolation-realgpu/README.md
           - "Part C - Inference benchmark (real GPU)": portfolio-lab/04-inference-serving/inference-realgpu/README.md
           - "Part D - Slurm real GRES": portfolio-lab/02-slurm-gpu-platform/slurm-realgpu/README.md
+      - "7 - Security (planned)": portfolio-lab/07-security/README.md
   - Deep dives:
       - kind (local cluster): portfolio-lab/01-k8s-gpu-platform/kind/README.md
       - KWOK (fake nodes): portfolio-lab/01-k8s-gpu-platform/kwok/README.md

--- a/portfolio-lab/07-security/README.md
+++ b/portfolio-lab/07-security/README.md
@@ -1,0 +1,52 @@
+# Lesson 7 - Security for GPU/AI Infrastructure
+
+> Course home: [AI Factory Operations Lab](../../README.md) · Tracked as
+> [issue #10](https://github.com/ld-singh/ai-factory-ops-lab/issues/10) on the
+> [roadmap](https://github.com/users/ld-singh/projects/1)
+
+> 🚧 **STATUS: PLANNED - coming in a future update.** This page is the outline. The
+> simulation-first lesson is on the roadmap; the shape below is what it will cover.
+
+Every other lesson gets a GPU platform *working*. This one asks the next question a real
+operator has to answer: **is it safe to run more than one tenant on it?** GPU platforms are
+expensive, so they get shared, and sharing is where the security work lives.
+
+🧭 **Mode:** 🟦 Simulation-first (on the same fake GPU fleet as Lessons 1-3). The controls
+here are control-plane controls, so most of it is provable without hardware.
+
+## What it will cover
+
+### 1. Multi-tenant isolation
+- Namespace-per-tenant boundaries, and what a namespace does and does not isolate on a
+  shared GPU node.
+- The gap between *scheduling* isolation (Lesson 1) and *runtime* isolation (HAMi, Lesson 1C/6B),
+  seen through a security lens: a memory cap is also a blast-radius control.
+
+### 2. RBAC and quotas as security controls
+- Least-privilege RBAC for who can request GPUs, edit workloads, and read telemetry.
+- ResourceQuota / LimitRange on `nvidia.com/gpu` as a denial-of-service guardrail, not just
+  a capacity one.
+
+### 3. Network boundaries
+- NetworkPolicy around inference endpoints (who can call the model server).
+- Locking down the metrics surface: DCGM exporter and Prometheus expose fleet detail that
+  shouldn't be world-readable.
+
+### 4. Secrets and supply chain
+- Handling model-registry and cloud credentials the workloads need.
+- Model-artifact provenance: where the weights came from, and why "pull any HF model" is a
+  supply-chain decision.
+
+### 5. The break-it drill
+- In the spirit of the observability lesson: misconfigure one control on purpose (an
+  over-broad RBAC role, a missing NetworkPolicy) and show the exposure, then close it.
+
+## What it will prove (and not)
+
+Provable for free: the control-plane security posture - RBAC, quotas, network policy,
+namespace boundaries, and the drills that verify them. It will **not** prove hardware-level
+tenant isolation (side channels, firmware, confidential computing), which is out of scope for
+this course's single-node, entry-GPU focus and is called out explicitly.
+
+> 💡 **Want to help shape or build this?** Comment on
+> [issue #10](https://github.com/ld-singh/ai-factory-ops-lab/issues/10).


### PR DESCRIPTION
Adds the open-source basics and the security lesson placeholder.

- LICENSE (MIT)
- CONTRIBUTING.md — how to run the labs, PR flow, and the house rules
- ROADMAP.md — themes + link to the project board
- portfolio-lab/07-security/ — Lesson 7 outline (planned), added to site nav

Closes #18