### PR TITLE
CI: add a link checker (lychee) on pull requests

### DIFF
--- a/.github/workflows/pr-links.yml
+++ b/.github/workflows/pr-links.yml
@@ -1,0 +1,65 @@
+name: PR link check
+
+# Catch broken links in the docs before merge (issue #21), complementing the mkdocs build
+# check (pr-docs.yml, #15). Two passes with different strictness:
+#   1. internal links (relative paths to files in the repo)  -> BLOCKING, deterministic
+#   2. external links (http/https URLs)                      -> ADVISORY, never blocks
+# Internal link rot (a lesson pointing at a renamed/moved file) is a real regression and is
+# fully under our control, so it fails the PR. External links depend on other people's sites
+# being up, so they are reported but never block a merge on a transient outage.
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - "lychee.toml"
+      - ".github/workflows/pr-links.yml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: pr-links-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The source markdown is the single source of truth (docs/ holds generated copies and
+      # is gitignored, so it is not present on a fresh checkout). Check the lesson trees and
+      # the top-level docs.
+      - name: Check internal links (blocking)
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # --offline verifies that every relative link points at a file that exists, and
+          # skips all URLs. This never touches the network, so it cannot be flaky.
+          args: >-
+            --offline
+            --no-progress
+            portfolio-lab/**/*.md
+            runbooks/**/*.md
+            diagrams/**/*.md
+            control-plane/**/*.md
+            ./*.md
+          fail: true
+
+      - name: Check external links (advisory)
+        uses: lycheeverse/lychee-action@v2
+        env:
+          # Authenticated GitHub requests avoid anonymous rate limiting (the repo has many
+          # github.com links). Uses the automatic, read-only workflow token.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: >-
+            --no-progress
+            portfolio-lab/**/*.md
+            runbooks/**/*.md
+            diagrams/**/*.md
+            control-plane/**/*.md
+            ./*.md
+          # Reachability of third-party sites is not something a PR should block on, so this
+          # pass reports dead external links without failing the check.
+          fail: false

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,23 @@
+# Config for the lychee link checker (CI: .github/workflows/pr-links.yml).
+# Docs: https://github.com/lycheeverse/lychee
+
+# Treat bot-blocked and rate-limited responses as OK so a live-but-unfriendly external
+# site does not fail the check. A genuine 404 (a real dead link) still fails.
+accept = ["200..=206", "403", "429"]
+
+# Be patient with slow or flaky external hosts before giving up.
+max_retries = 3
+retry_wait_time = 2
+timeout = 20
+
+# The labs use example endpoints like http://localhost:8000 / :9090; skip localhost and
+# any private/loopback address, none of which are reachable from CI.
+exclude_all_private = true
+
+# Hosts and placeholders that cannot be checked automatically:
+exclude = [
+  # <vm-ip>, <user>@<vm-ip> and similar placeholders written as URLs in the labs.
+  '^https?://<',
+  # LinkedIn returns 999/403 to any automated client, so it is never verifiable here.
+  'linkedin\.com',
+]


### PR DESCRIPTION
Adds a link checker (lychee) that runs on pull requests, complementing the mkdocs build check (#15).

Closes #21.

## What it does

New workflow [`.github/workflows/pr-links.yml`](.github/workflows/pr-links.yml): on PRs touching markdown, it checks the docs' links in two passes with different strictness.

- **Internal links (blocking).** `lychee --offline` verifies every relative link points at a file that exists. This never touches the network, so it is deterministic and cannot be flaky. Link rot, a lesson pointing at a renamed or moved file, fails the PR. Verified locally: 409 internal file links across 53 markdown files currently resolve, so this passes on the current tree.
- **External links (advisory).** A second `lychee` pass checks http/https URLs but with `fail: false`, so it reports dead external links without blocking. A third-party site being briefly down should never block a merge, and the repo has 200+ external links (HAMi, NVIDIA, k3s, GitHub) whose uptime we do not control.

## Config

[`lychee.toml`](lychee.toml) keeps the external pass honest without false failures:
- accepts `403`/`429` (bot-blocked / rate-limited) as OK, with retries and a timeout, so a live-but-unfriendly host does not fail the check while a real `404` still would;
- skips `localhost` and private addresses (the labs use example endpoints like `http://localhost:8000`);
- excludes LinkedIn (returns 999/403 to any automated client) and `<vm-ip>`-style placeholders.

The external pass also uses the automatic read-only `GITHUB_TOKEN` so the many `github.com` links are not anonymously rate-limited.

## Relationship to #19

#19 (shared `.md` URLs 404ing on the site) was a site-serving quirk fixed by the 404 redirect; it is not reproducible from the repo source, since these links point at real files. This checker targets the broader class the issue asks for: broken links caught before merge, deterministically for internal link rot.
